### PR TITLE
fix haa (home accessory architect) setup button

### DIFF
--- a/homeassistant/components/homekit_controller/button.py
+++ b/homeassistant/components/homekit_controller/button.py
@@ -33,22 +33,34 @@ class HomeKitButtonEntityDescription(ButtonEntityDescription):
 
     write_value: int | str | None = None
 
+"""
+HAA has 1 custom characteristic on F0000101-0218-2017-81BF-AF2B7C833922
+aid is 1 , iid : 65011.
+to trigger command you must write:
+- Update -> #HAA@trcmd0
+- Setup  -> #HAA@trcmd1
+- Reboot -> #HAA@trcmd2
+- Wifi Reconnection -> #HAA@trcmd3
 
+@ on aiohomekit VENDOR_HAA_UPDATE/VENDOR_HAA_SETUP has different chars but on new version the characteristic is only one
+To debug open a netcat: 
+nc -kulnw0 45678
+"""
 BUTTON_ENTITIES: dict[str, HomeKitButtonEntityDescription] = {
-    CharacteristicsTypes.VENDOR_HAA_SETUP: HomeKitButtonEntityDescription(
-        key=CharacteristicsTypes.VENDOR_HAA_SETUP,
+    CharacteristicsTypes.VENDOR_HAA_UPDATE: HomeKitButtonEntityDescription(
+        key=CharacteristicsTypes.VENDOR_HAA_UPDATE,
         name="Setup",
         icon="mdi:cog",
         entity_category=EntityCategory.CONFIG,
-        write_value="#HAA@trcmd",
+        write_value="#HAA@trcmd1",
     ),
-    CharacteristicsTypes.VENDOR_HAA_UPDATE: HomeKitButtonEntityDescription(
-        key=CharacteristicsTypes.VENDOR_HAA_UPDATE,
-        name="Update",
-        device_class=ButtonDeviceClass.UPDATE,
-        entity_category=EntityCategory.CONFIG,
-        write_value="#HAA@trcmd",
-    ),
+  #  CharacteristicsTypes.VENDOR_HAA_UPDATE: HomeKitButtonEntityDescription(
+  #      key=CharacteristicsTypes.VENDOR_HAA_UPDATE,
+  #      name="Update",
+  #      device_class=ButtonDeviceClass.UPDATE,
+  #     entity_category=EntityCategory.CONFIG,
+  #      write_value="#HAA@trcmd0",
+  #  ),
     CharacteristicsTypes.IDENTIFY: HomeKitButtonEntityDescription(
         key=CharacteristicsTypes.IDENTIFY,
         name="Identify",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

This PR fixes the HAA (home accessory architect) button to enter in Setup mode. HAA changed the way to handle the custom homekit characteristics and after a reverse engineering I found out the protocol:
HAA has 1 custom characteristic on F0000101-0218-2017-81BF-AF2B7C833922
to trigger command you must write:
- Update -> #HAA@trcmd0
- Setup  -> #HAA@trcmd1
- Reboot -> #HAA@trcmd2
- Wifi Reconnection -> #HAA@trcmd3

this PR is just a temporary fix keeping the other dependencies as they are. aiohomekit exposes two different chars as they were before ( CharacteristicsTypes.VENDOR_HAA_UPDATE / CharacteristicsTypes.VENDOR_HAA_SETUP) but in reality now haa uses only CharacteristicsTypes.VENDOR_HAA_UPDATE. I didn't change the name in aiohomekit but it should be done to me.

The available features are 4 (setup/update/reboot/wifi reconnection)  but I enabled only Setup.
I tried to enable all but there are more stuff to change : for instance being on all same characteristic the different button have the same unique_id and cannot be declared. Moreover the BUTTON_ENTITIES is a dictionary but for the same reason above there should be a problem with multiple key if we keep the dictionary container.

Unfortunately I have no time to modify all and I guess an intermediate step is better.

Having only Setup button is enough to me because from that state you can update/reboot/reconnect the device.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
