### PR TITLE
map heatercooler rotation speed as 3 level fan speed

### DIFF
--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -23,6 +23,11 @@ from homeassistant.components.climate import (
     DEFAULT_MAX_TEMP,
     DEFAULT_MIN_TEMP,
     FAN_AUTO,
+    FAN_LOW ,
+    FAN_MEDIUM ,
+    FAN_MIDDLE,
+    FAN_HIGH ,
+    FAN_OFF,
     FAN_ON,
     SWING_OFF,
     SWING_VERTICAL,
@@ -86,6 +91,9 @@ SWING_MODE_HASS_TO_HOMEKIT = {v: k for k, v in SWING_MODE_HOMEKIT_TO_HASS.items(
 
 DEFAULT_MIN_STEP: Final = 1.0
 
+ROTATION_SPEED_LOW = 33
+ROTATION_SPEED_MEDIUM = 66
+ROTATION_SPEED_HIGH = 100
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -170,7 +178,48 @@ class HomeKitHeaterCoolerEntity(HomeKitBaseClimateEntity):
             CharacteristicsTypes.TEMPERATURE_COOLING_THRESHOLD,
             CharacteristicsTypes.TEMPERATURE_HEATING_THRESHOLD,
             CharacteristicsTypes.SWING_MODE,
+            CharacteristicsTypes.ROTATION_SPEED,
         ]
+
+    @property
+    def fan_modes(self) -> list[str] | None:
+        """Return the available fan modes."""
+        if self.service.has(CharacteristicsTypes.ROTATION_SPEED):
+            return [FAN_OFF,FAN_LOW, FAN_MEDIUM, FAN_HIGH]
+        return None
+
+    @property
+    def fan_mode(self) -> str | None:
+        """Return the current fan mode."""
+        speed = self.service.value(CharacteristicsTypes.ROTATION_SPEED)
+        fan_mode = FAN_OFF
+       
+        #homekit seems to set value 0 33 66 100
+        if speed > ROTATION_SPEED_MEDIUM :
+            fan_mode = FAN_HIGH
+        elif speed > ROTATION_SPEED_LOW :
+            fan_mode = FAN_MEDIUM
+        elif speed > 0 :
+            fan_mode = FAN_LOW
+        elif speed <= 0 :    
+            fan_mode = FAN_OFF
+
+        return fan_mode
+
+    async def async_set_fan_mode(self, fan_mode: str) -> None:
+        rotation = 0
+        if fan_mode == FAN_LOW:
+            rotation = ROTATION_SPEED_LOW
+        elif fan_mode == FAN_MEDIUM:
+            rotation = ROTATION_SPEED_MEDIUM 
+        elif fan_mode == FAN_HIGH:
+            rotation = ROTATION_SPEED_HIGH 
+
+        _LOGGER.warning("set %d",rotation)
+        await self.async_put_characteristics(
+            {CharacteristicsTypes.ROTATION_SPEED: int(rotation)}
+        )
+
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
@@ -386,6 +435,9 @@ class HomeKitHeaterCoolerEntity(HomeKitBaseClimateEntity):
 
         if self.service.has(CharacteristicsTypes.SWING_MODE):
             features |= ClimateEntityFeature.SWING_MODE
+
+        if self.service.has(CharacteristicsTypes.ROTATION_SPEED):
+            features |= ClimateEntityFeature.FAN_MODE
 
         return features
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

 This PR map the heaterCooler (not handled until now) homekit in 3 level (LOW,MEDIUM,HIGH) fan speed.


This is original Apple homeAPP with rotation speed:
<img width="517" alt="Screenshot 2023-08-05 alle 09 05 32" src="https://github.com/freedreamer82/core/assets/5691521/870a169e-ca2b-462f-a164-03d49a459e9f">

And this is heatercooler handled by HA controller and exported to Apple APP:

<img width="522" alt="Screenshot 2023-08-12 alle 09 48 13" src="https://github.com/freedreamer82/core/assets/5691521/fd8746c8-2478-44ac-b3ae-31c893d66b42">


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
